### PR TITLE
Update dev installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ shardguard plan "Your prompt" --provider gemini --gemini-api-key "your-key"
 
 ```bash
 # Install dependencies
-poetry install
+poetry install -E dev
 
 # Install pre-commit hooks (required for each developer)
 poetry run pre-commit install


### PR DESCRIPTION
This PR fixes the dev installation instructions in the README.

Currently, the README instructs users interested in developing ShardGuard to install dependencies via `poetry install`, when it should be `poetry install -E dev`. As written, the instructions fail on the next line `poetry run pre-commit install` as `pre-commit` is only included in the dev dependencies.  