### PR TITLE
List tools functionality

### DIFF
--- a/src/shardguard/cli.py
+++ b/src/shardguard/cli.py
@@ -121,11 +121,11 @@ def _print_verbose_tools_info(tools_description: str) -> None:
     """Print detailed server and tool information."""
     for line in tools_description.split("\n"):
         stripped_line = line.strip()
-        if stripped_line.startswith("Server:"):
-            server_name = stripped_line.replace("Server:", "").strip()
+        if "server:" in stripped_line.lower():
+            server_name = stripped_line.lower().replace("Server:", "").strip()
             console.print(f"[bold cyan]{server_name}[/bold cyan]")
-        elif stripped_line.startswith("•"):
-            tool_name = stripped_line.replace("•", "").strip()
+        elif "tool_key" in stripped_line.lower():
+            tool_name = stripped_line.replace("-", "").strip()
             if ":" in tool_name:
                 tool_name = tool_name.split(":")[0]
             console.print(f"  └── [green]{tool_name}[/green]")


### PR DESCRIPTION
Clickup Task [86dyyy63h](https://app.clickup.com/t/86dyyy63h):
> Create functionality so user can ask ShardGuard at any time to list the tools available
> My idea is this should be in registry and then adding the command in cli.py
> @registry_app.command("list-tools")
> def registry_list_tools(
> 
> poetry run shardguard list-tools

`list_tools` [already exists](https://github.com/JustinCappos/ShardGuard/commit/8f5561efd3224d55607f1e36a2b507e9ff1dc9f0#diff-3ad2f123caff6e157dcdef2caa45558c9f2a358f944633b58c07fcec6281e2c5R25-R154). Have updated parsing mechanism to make it work.